### PR TITLE
Backwards compatible with <=jruby1.7.18 and <ruby2.0

### DIFF
--- a/lib/fb_graph2.rb
+++ b/lib/fb_graph2.rb
@@ -7,7 +7,14 @@ module FbGraph2
 
   self.root_url = 'https://graph.facebook.com'
   self.api_version = 'v2.3'
-  self.gem_version = File.read(File.join(__dir__, '../VERSION')).strip
+  begin
+    self.gem_version = File.read(File.join(__dir__, '../VERSION')).strip
+  rescue NameError => e
+    self.gem_version = ::File.read(
+        ::File.join(::File.dirname(__FILE__), '../VERSION')
+    ).strip
+  end
+
   self.logger = Logger.new(STDOUT)
   self.logger.progname = 'FbGraph2'
   self.object_classes = Array.new
@@ -50,7 +57,12 @@ require_relative 'fb_graph2/edge'
   '',
   'request_filter'
 ].each do |dir|
-  Dir[File.join(__dir__, 'fb_graph2', dir, '*.rb')].each do |file|
+  begin
+    _files_to_be_required = Dir[File.join(__dir__, 'fb_graph2', dir, '*.rb')]
+  rescue NameError => e
+    _files_to_be_required = Dir[File.join(File.dirname(File.realpath(__FILE__)), 'fb_graph2', dir, '*.rb')]
+  end
+  _files_to_be_required.each do |file|
     require file
   end
 end

--- a/lib/fb_graph2/auth.rb
+++ b/lib/fb_graph2/auth.rb
@@ -54,6 +54,11 @@ module FbGraph2
   end
 end
 
-Dir[File.join(__dir__, 'auth/*.rb')].each do |file|
+begin
+  _files_to_require = Dir[File.join(__dir__, 'auth/*.rb')]
+rescue NameError => e
+  _files_to_require = Dir[File.join(File.dirname(File.realpath(__FILE__)), 'auth/*.rb')]
+end
+_files_to_require.each do |file|
   require file
 end

--- a/lib/fb_graph2/edge.rb
+++ b/lib/fb_graph2/edge.rb
@@ -34,6 +34,11 @@ module FbGraph2
   end
 end
 
-Dir[File.join(__dir__, 'edge/*.rb')].each do |file|
+begin
+  _files_to_require = Dir[File.join(__dir__, 'edge/*.rb')]
+rescue NameError => e
+  _files_to_require = Dir[File.join(File.dirname(File.realpath(__FILE__)), 'edge/*.rb')]
+end
+_files_to_require.each do |file|
   require file
 end

--- a/lib/fb_graph2/struct.rb
+++ b/lib/fb_graph2/struct.rb
@@ -10,6 +10,11 @@ module FbGraph2
   end
 end
 
-Dir[File.join(__dir__, 'struct/*.rb')].each do |file|
+begin
+  _files_to_require = Dir[File.join(__dir__, 'struct/*.rb')]
+rescue NameError => e
+  _files_to_require = Dir[File.join(File.dirname(File.realpath(__FILE__)), 'struct/*.rb')]
+end
+_files_to_require.each do |file|
   require file
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,12 @@ RSpec.configure do |config|
     c.syntax = [:should, :expect]
   end
 end
+begin
+	_files_to_require = Dir[File.join(__dir__, 'spec_helper/*.rb')]
+rescue
+	_files_to_require = Dir[File.join(File.dirname(File.realpath(__FILE__)), 'spec_helper/*.rb')]
+end
 
-Dir[File.join(__dir__, 'spec_helper/*.rb')].each do |file|
+_files_to_require.each do |file|
   require file
 end


### PR DESCRIPTION
added backwards compatibility for older ruby/jruby versions for a particular method name  that was not supported
